### PR TITLE
Initial support for soft delete

### DIFF
--- a/api/models/DeletedRecord.js
+++ b/api/models/DeletedRecord.js
@@ -1,0 +1,24 @@
+/**
+ * Record.js
+ *
+ * @description :: The Deleted Record Model for ReDBox
+ * @docs        :: http://sailsjs.org/documentation/concepts/models-and-orm/models
+ */
+
+module.exports = {
+    attributes: {
+      redboxOid: {
+        type: 'string',
+        unique: true
+      },
+      deletedRecordMetadata: {
+        type: 'json'
+      },
+      dateDeleted: {
+        type: 'string',
+        autoCreatedAt: true
+      }
+    },
+    datastore: 'redboxStorage'
+  };
+  


### PR DESCRIPTION
Updates the driver so that by default deleting a record:
1. Creates an entry in the deletedrecord collection with a copy of the original record in the deletedRecordMetadata
2. Deletes the record from the record collection

Existing permanent delete functionality has been preserved by passing the boolean true to the delete function