### PR TITLE
Fix: Export Date String

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@researchdatabox/sails-hook-redbox-storage-mongo",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "A MongoDB storage plugin for ReDBox.",
   "main": "index.js",
   "sails": {

--- a/typescript/api/services/MongoStorageService.ts
+++ b/typescript/api/services/MongoStorageService.ts
@@ -616,10 +616,9 @@ export module Services {
         });
       }
       if (!_.isEmpty(modBefore)) {
-        let modBeforeString = moment(modBefore, 'YYYY-MM-DD').add(1, 'days').format('YYYY-MM-DD')
         andArray.push({
           lastSaveDate: {
-            '$lte': `${modBeforeString}`
+            '$lte': `${modBefore}`
           }
         });
       }


### PR DESCRIPTION
Previously the export function was expecting from and to dates in YYYY-MM-DD format. This seems to no longer work with MongoDB 6.
To resolve this issue and to provide more flexibility to our APIs, the export function now requires ISO8601 dates.
This makes the adding of a day to the "to date" (modBefore) redundant as the date should now include the time component and be set appropriately for the export (e.g. 23:59:59.999 for the end of a day).